### PR TITLE
Fixes crash when no shared string index present.

### DIFF
--- a/EPPlus/ExcelWorksheet.cs
+++ b/EPPlus/ExcelWorksheet.cs
@@ -1488,11 +1488,22 @@ namespace OfficeOpenXml
             //if (vnode == null) return null;
             if (type == "s")
             {
-                int ix = xr.ReadElementContentAsInt();
-                SetValueInner(row, col, _package.Workbook._sharedStringsList[ix].Text);
-                if (_package.Workbook._sharedStringsList[ix].isRichText)
+                var content = xr.ReadElementContentAsString();
+                int ix;
+
+                // if the shared string index isn't present or is a valid number
+                // then just use the content
+                if (!int.TryParse(content, out ix))
                 {
-                    _flags.SetFlagValue(row, col, true, CellFlags.RichText);
+                    SetValueInner(row, col, content);
+                }
+                else
+                {
+                    SetValueInner(row, col, _package.Workbook._sharedStringsList[ix].Text);
+                    if (_package.Workbook._sharedStringsList[ix].isRichText)
+                    {
+                        _flags.SetFlagValue(row, col, true, CellFlags.RichText);
+                    }
                 }
             }
             else if (type == "str")

--- a/EPPlus/ExcelWorksheet.cs
+++ b/EPPlus/ExcelWorksheet.cs
@@ -1491,7 +1491,7 @@ namespace OfficeOpenXml
                 var content = xr.ReadElementContentAsString();
                 int ix;
 
-                // if the shared string index isn't present or is a valid number
+                // if the shared string index isn't present or is not a valid number
                 // then just use the content
                 if (!int.TryParse(content, out ix))
                 {


### PR DESCRIPTION
I received an Excel file that could not be opened because it caused a crash. After some debugging I determined that it is because the v element within a c element doesn't have a value and the existing code expects there to always be a value.

![image](https://user-images.githubusercontent.com/136175/176505293-e40aba22-cf3a-4872-9da7-f28648957314.png)

The file was generated by an external vendor, so I cannot alter how it is generated. The file can be opened by Excel and LibreOffice Calc with no issues.

I have produced a sample of the "broken" file here.

[Book1.xlsx](https://github.com/rimland/EPPlus/files/9012979/Book1.xlsx)

This fix ensures that the shared string index is read as a string and parsed safely and the appropriate content placed into the cell.

