### PR TITLE
Fix calculations on .NET Framework

### DIFF
--- a/EPPlus/FormulaParsing/ExpressionGraph/DecimalExpression.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/DecimalExpression.cs
@@ -61,7 +61,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
 
         public override CompileResult Compile()
         {
-            double result = _compiledValue.HasValue ? _compiledValue.Value : double.Parse(ExpressionString, CultureInfo.InvariantCulture);
+            double result = _compiledValue ?? double.Parse(ExpressionString, CultureInfo.InvariantCulture);
             result = _negate ? result * -1 : result;
             return new CompileResult(result, DataType.Decimal);
         }

--- a/EPPlus/FormulaParsing/ExpressionGraph/IntegerExpression.cs
+++ b/EPPlus/FormulaParsing/ExpressionGraph/IntegerExpression.cs
@@ -61,7 +61,7 @@ namespace OfficeOpenXml.FormulaParsing.ExpressionGraph
 
         public override CompileResult Compile()
         {
-            double result = _compiledValue.HasValue ? _compiledValue.Value : double.Parse(ExpressionString, CultureInfo.InvariantCulture);
+            double result = _compiledValue ?? double.Parse(ExpressionString, CultureInfo.InvariantCulture);
             result = _negate ? result*-1 : result;
             return new CompileResult(result, DataType.Integer);
         }


### PR DESCRIPTION
Fixes performing recalculation on .NET Framework when run on Windows 10 / .NET Framework 4.8.1
